### PR TITLE
Feature/section 5

### DIFF
--- a/src/main/java/tobyspring/splearn/application/provided/MemberRegister.java
+++ b/src/main/java/tobyspring/splearn/application/provided/MemberRegister.java
@@ -1,0 +1,12 @@
+package tobyspring.splearn.application.provided;
+
+import tobyspring.splearn.domain.Member;
+import tobyspring.splearn.domain.MemberRegisterRequest;
+
+/**
+ * 회원의 등록과 관련된 작업을 한다.
+ */
+public interface MemberRegister {
+
+    Member register(MemberRegisterRequest memberRegisterRequest);
+}

--- a/src/main/java/tobyspring/splearn/application/required/EmailSender.java
+++ b/src/main/java/tobyspring/splearn/application/required/EmailSender.java
@@ -1,0 +1,11 @@
+package tobyspring.splearn.application.required;
+
+import tobyspring.splearn.domain.Email;
+
+/**
+ * 이메일을 발송한다.
+ */
+public interface EmailSender {
+
+    void send(Email email, String subject, String body);
+}

--- a/src/main/java/tobyspring/splearn/application/required/MemberRepository.java
+++ b/src/main/java/tobyspring/splearn/application/required/MemberRepository.java
@@ -1,0 +1,12 @@
+package tobyspring.splearn.application.required;
+
+import org.springframework.data.repository.Repository;
+import tobyspring.splearn.domain.Member;
+
+/**
+ * 회원 정보를 저장하거나 조회한다.
+ */
+public interface MemberRepository extends Repository<Member, Long> {
+
+    Member save(Member member);
+}

--- a/src/main/java/tobyspring/splearn/domain/Email.java
+++ b/src/main/java/tobyspring/splearn/domain/Email.java
@@ -1,7 +1,16 @@
 package tobyspring.splearn.domain;
 
+import jakarta.persistence.Embeddable;
+
 import java.util.regex.Pattern;
 
+/**
+ * 원래 @Embeddable은 기본 생성자가 필요함
+ * record는 기본 생성자를 만들어주지 않아서 jpa, hibernate 구 버전에서는 규약 위반
+ *
+ * hibernate 6.x, jpa 3.2 버전부터 record를 지원함
+ */
+@Embeddable
 public record Email(String address) {
     private static final Pattern EMAIL_PATTERN =
             Pattern.compile("^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,7}$");

--- a/src/main/java/tobyspring/splearn/domain/Member.java
+++ b/src/main/java/tobyspring/splearn/domain/Member.java
@@ -1,24 +1,42 @@
 package tobyspring.splearn.domain;
 
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 import static java.util.Objects.requireNonNull;
+import static lombok.AccessLevel.PROTECTED;
 import static org.springframework.util.Assert.state;
 
+/**
+ * 코드에 어노테이션이 있다고 기술에 의존적(종속적)으로 되었는가?
+ * JPA가 없으면 사용할 수 없는 코드인가?
+ *
+ * 어노테이션의 의미는 주석
+ * 어노테이션 때문에 특별한 동작을 수행하는 프레임워크가 아니라면 기술에 의존인건 아님
+ * 순수한 도메인으로 만들었을 때와 코드가 달라져야하는데, 어노테이션만으로는 차이가 없음
+ */
 @Getter
+@Entity
 @ToString
+@NoArgsConstructor(access = PROTECTED)
 public class Member {
+    @Id
+    private Long id;
+
+    @Embedded
     private Email email;
 
     private String nickname;
 
     private String passwordHash;
 
+    @Enumerated
     private MemberStatus status;
-
-    private Member() {
-    }
 
     public static Member register(MemberRegisterRequest memberRegisterRequest, PasswordEncoder passwordEncoder) {
         Member member = new Member();

--- a/src/main/java/tobyspring/splearn/domain/Member.java
+++ b/src/main/java/tobyspring/splearn/domain/Member.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.hibernate.annotations.NaturalId;
+import org.hibernate.annotations.NaturalIdCache;
 
 import static java.util.Objects.requireNonNull;
 import static lombok.AccessLevel.PROTECTED;
@@ -20,6 +22,7 @@ import static org.springframework.util.Assert.state;
 @Getter
 @Entity
 @ToString
+@NaturalIdCache // 영속성 컨텍스트에서 @NaturalId가 붙은 필드를 기준으로 캐싱해줌
 @NoArgsConstructor(access = PROTECTED)
 public class Member {
     @Id
@@ -27,6 +30,7 @@ public class Member {
     private Long id;
 
     @Embedded
+    @NaturalId // hibernate에서 제공하는 어노테이션으로 테이블 생성 시 컬럼에 유니크키 설정이 됨
     private Email email;
 
     private String nickname;

--- a/src/main/java/tobyspring/splearn/domain/Member.java
+++ b/src/main/java/tobyspring/splearn/domain/Member.java
@@ -20,12 +20,12 @@ public class Member {
     private Member() {
     }
 
-    public static Member create(MemberCreateRequest memberCreateRequest, PasswordEncoder passwordEncoder) {
+    public static Member register(MemberRegisterRequest memberRegisterRequest, PasswordEncoder passwordEncoder) {
         Member member = new Member();
 
-        member.email = new Email(memberCreateRequest.email());
-        member.nickname = requireNonNull(memberCreateRequest.nickname());
-        member.passwordHash = requireNonNull(passwordEncoder.encode(memberCreateRequest.password()));
+        member.email = new Email(memberRegisterRequest.email());
+        member.nickname = requireNonNull(memberRegisterRequest.nickname());
+        member.passwordHash = requireNonNull(passwordEncoder.encode(memberRegisterRequest.password()));
         member.status = MemberStatus.PENDING;
 
         return member;

--- a/src/main/java/tobyspring/splearn/domain/Member.java
+++ b/src/main/java/tobyspring/splearn/domain/Member.java
@@ -1,9 +1,6 @@
 package tobyspring.splearn.domain;
 
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
@@ -26,6 +23,7 @@ import static org.springframework.util.Assert.state;
 @NoArgsConstructor(access = PROTECTED)
 public class Member {
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Embedded
@@ -35,7 +33,7 @@ public class Member {
 
     private String passwordHash;
 
-    @Enumerated
+    @Enumerated(EnumType.STRING)
     private MemberStatus status;
 
     public static Member register(MemberRegisterRequest memberRegisterRequest, PasswordEncoder passwordEncoder) {

--- a/src/main/java/tobyspring/splearn/domain/MemberCreateRequest.java
+++ b/src/main/java/tobyspring/splearn/domain/MemberCreateRequest.java
@@ -1,4 +1,0 @@
-package tobyspring.splearn.domain;
-
-public record MemberCreateRequest(String email, String nickname, String password) {
-}

--- a/src/main/java/tobyspring/splearn/domain/MemberRegisterRequest.java
+++ b/src/main/java/tobyspring/splearn/domain/MemberRegisterRequest.java
@@ -1,0 +1,4 @@
+package tobyspring.splearn.domain;
+
+public record MemberRegisterRequest(String email, String nickname, String password) {
+}

--- a/src/main/java/tobyspring/splearn/domain/PasswordEncoder.java
+++ b/src/main/java/tobyspring/splearn/domain/PasswordEncoder.java
@@ -1,5 +1,10 @@
 package tobyspring.splearn.domain;
 
+/**
+ * PasswordEncoder의 기술적인 요소 때문에 required에 위치시켜야하는 의문이 들 수 있음
+ * required에 두면 Member(도메인)이 required를 의존하기 때문에 역방향이 됨
+ * domain도 application 내부에 있기 때문에 PasswordEncoder는 domain에 위치해도 된다는 내용
+ */
 public interface PasswordEncoder {
 
     String encode(String password);

--- a/src/test/java/tobyspring/splearn/application/required/MemberRepositoryTest.java
+++ b/src/test/java/tobyspring/splearn/application/required/MemberRepositoryTest.java
@@ -1,0 +1,36 @@
+package tobyspring.splearn.application.required;
+
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import tobyspring.splearn.domain.Member;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static tobyspring.splearn.domain.MemberFixture.createMemberRegisterRequest;
+import static tobyspring.splearn.domain.MemberFixture.createPasswordEncoder;
+
+@DataJpaTest
+@DisplayName("MemberRepository")
+class MemberRepositoryTest {
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    EntityManager entityManager;
+
+    @Test
+    @DisplayName("create()")
+    void test1() {
+        Member member = Member.register(createMemberRegisterRequest(), createPasswordEncoder());
+
+        assertThat(member.getId()).isNull();
+
+        memberRepository.save(member);
+
+        assertThat(member.getId()).isNotNull();
+
+        entityManager.flush();
+    }
+}

--- a/src/test/java/tobyspring/splearn/application/required/MemberRepositoryTest.java
+++ b/src/test/java/tobyspring/splearn/application/required/MemberRepositoryTest.java
@@ -5,9 +5,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
 import tobyspring.splearn.domain.Member;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static tobyspring.splearn.domain.MemberFixture.createMemberRegisterRequest;
 import static tobyspring.splearn.domain.MemberFixture.createPasswordEncoder;
 
@@ -32,5 +34,16 @@ class MemberRepositoryTest {
         assertThat(member.getId()).isNotNull();
 
         entityManager.flush();
+    }
+
+    @Test
+    @DisplayName("중복 이메일일 때 실패")
+    void test2() {
+        Member member = Member.register(createMemberRegisterRequest(), createPasswordEncoder());
+        memberRepository.save(member);
+
+        Member member2 = Member.register(createMemberRegisterRequest(), createPasswordEncoder());
+        assertThatThrownBy(() -> memberRepository.save(member2))
+                .isInstanceOf(DataIntegrityViolationException.class);
     }
 }

--- a/src/test/java/tobyspring/splearn/domain/MemberFixture.java
+++ b/src/test/java/tobyspring/splearn/domain/MemberFixture.java
@@ -1,0 +1,26 @@
+package tobyspring.splearn.domain;
+
+public class MemberFixture {
+
+    public static MemberRegisterRequest createMemberRegisterRequest(String email) {
+        return new MemberRegisterRequest(email, "test", "password");
+    }
+
+    public static MemberRegisterRequest createMemberRegisterRequest() {
+        return createMemberRegisterRequest("test@app.com");
+    }
+
+    public static PasswordEncoder createPasswordEncoder() {
+        return new PasswordEncoder() {
+            @Override
+            public String encode(String password) {
+                return password.toUpperCase();
+            }
+
+            @Override
+            public boolean matches(String password, String passwordHash) {
+                return encode(password).equals(passwordHash);
+            }
+        };
+    }
+}

--- a/src/test/java/tobyspring/splearn/domain/MemberTest.java
+++ b/src/test/java/tobyspring/splearn/domain/MemberTest.java
@@ -28,7 +28,7 @@ class MemberTest {
             }
         };
 
-        this.member = Member.create(new MemberCreateRequest("test@app.com", "test", "password"), passwordEncoder);
+        this.member = Member.register(new MemberRegisterRequest("test@app.com", "test", "password"), passwordEncoder);
     }
 
     @Test
@@ -41,7 +41,7 @@ class MemberTest {
     @Test
     @DisplayName("생성자 NULL 체크")
     void test2() {
-        assertThatThrownBy(() -> Member.create(new MemberCreateRequest(null, "test", "password"), passwordEncoder))
+        assertThatThrownBy(() -> Member.register(new MemberRegisterRequest(null, "test", "password"), passwordEncoder))
                 .isInstanceOf(NullPointerException.class);
     }
 
@@ -128,9 +128,9 @@ class MemberTest {
     @DisplayName("유효하지 않은 이메일 검증")
     void test11() {
         assertThatThrownBy(() ->
-                Member.create(new MemberCreateRequest("invalid email", "nick", "pass"), passwordEncoder)
+                Member.register(new MemberRegisterRequest("invalid email", "nick", "pass"), passwordEncoder)
         ).isInstanceOf(IllegalArgumentException.class);
 
-        Member.create(new MemberCreateRequest("email@github.com", "nick", "pass"), passwordEncoder);
+        Member.register(new MemberRegisterRequest("email@github.com", "nick", "pass"), passwordEncoder);
     }
 }

--- a/src/test/java/tobyspring/splearn/domain/MemberTest.java
+++ b/src/test/java/tobyspring/splearn/domain/MemberTest.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static tobyspring.splearn.domain.MemberFixture.createMemberRegisterRequest;
+import static tobyspring.splearn.domain.MemberFixture.createPasswordEncoder;
 
 @DisplayName("Member")
 class MemberTest {
@@ -16,19 +18,9 @@ class MemberTest {
 
     @BeforeEach
     void setUp() {
-        this.passwordEncoder = new PasswordEncoder() {
-            @Override
-            public String encode(String password) {
-                return password.toUpperCase();
-            }
+        this.passwordEncoder = createPasswordEncoder();
 
-            @Override
-            public boolean matches(String password, String passwordHash) {
-                return encode(password).equals(passwordHash);
-            }
-        };
-
-        this.member = Member.register(new MemberRegisterRequest("test@app.com", "test", "password"), passwordEncoder);
+        this.member = Member.register(createMemberRegisterRequest(), passwordEncoder);
     }
 
     @Test
@@ -128,9 +120,9 @@ class MemberTest {
     @DisplayName("유효하지 않은 이메일 검증")
     void test11() {
         assertThatThrownBy(() ->
-                Member.register(new MemberRegisterRequest("invalid email", "nick", "pass"), passwordEncoder)
+                Member.register(createMemberRegisterRequest("invalid email"), passwordEncoder)
         ).isInstanceOf(IllegalArgumentException.class);
 
-        Member.register(new MemberRegisterRequest("email@github.com", "nick", "pass"), passwordEncoder);
+        Member.register(createMemberRegisterRequest(), passwordEncoder);
     }
 }

--- a/도메인모델.md
+++ b/도메인모델.md
@@ -50,24 +50,24 @@ _Entity_
 - `passwordHash`: 비밀번호
 - `status`: `MemberStatus` 회원 상태
 #### 행위
-- `static create()`: 회원 생성: email. nickname, password, passwordEncoder
-- `activate()`: 가입을 완료 시킨다
+- `static register()`: 회원 등록: email. nickname, password, passwordEncoder
+- `activate()`: 등록을 완료 시킨다
 - `deactivate()`: 탈퇴 시킨다
 - `verifyPassword()`: 비밀번호를 검증한다
 - `changeNickname()`: 닉네임을 변경한다
 - `changePassword()`: 비밀번호를 변경한다
 #### 규칙
-- 회원 생성 후 상태는 가입 대기
-- 일정조건을 만족하면 가입 완료가 된다
-- 가입 대기 상태에서만 가입 완료가 될 수 있다
-- 가입 완료 상태에서는 탈퇴할 수 있다
+- 회원 생성 후 상태는 등록 대기
+- 일정조건을 만족하면 등록 완료가 된다
+- 등록 대기 상태에서만 등록 완료가 될 수 있다
+- 등록 완료 상태에서는 탈퇴할 수 있다
 - 회원의 비밀번호는 해시를 만들어서 저장한다
 
 ### 회원 상태(MemberStatus)
 _Enum_
 #### 상수
-- `PENDING`: 가입 대기
-- `ACTIVE`: 가입 완료
+- `PENDING`: 등록 대기
+- `ACTIVE`: 등록 완료
 - `DEACTIVATED`: 탈퇴
 
 ### 비밀번호 인코더(PasswordEncoder)


### PR DESCRIPTION
도메인 용어는 개발(업무)가 진행 중이더라도 지속적으로 관리한다는 점

`@NaturalId`, `@NaturalIdCache`를 통한 유니크키 정의
기존에는 `@Column(unique = true)`정도로만 사용해옴
`@NaturalIdCache`까지 조합하여 영속성 컨텍스트에서 캐싱할 수 있음

논란이 많은 `Jpa 엔티티와 도메인 엔티티를 동일하게 볼 것인가?`에 대한 언급이 나옴
토비 선생님 입장은 Jpa, Hibernate 어노테이션이 있다고 해서 코드 엔티티의 동작방식이 달라지지 않기 때문에 문제 없다는 입장
