### PR TITLE
Feature/section 7

### DIFF
--- a/src/main/java/tobyspring/splearn/adapter/integration/DummyEmailSender.java
+++ b/src/main/java/tobyspring/splearn/adapter/integration/DummyEmailSender.java
@@ -2,8 +2,8 @@ package tobyspring.splearn.adapter.integration;
 
 import org.springframework.context.annotation.Fallback;
 import org.springframework.stereotype.Component;
-import tobyspring.splearn.application.required.EmailSender;
-import tobyspring.splearn.domain.Email;
+import tobyspring.splearn.application.member.required.EmailSender;
+import tobyspring.splearn.domain.shared.Email;
 
 @Fallback // 동일한 Bean 존재하지 않을 때만 사용, 동일한 Bean이 존재할 경우 미사용, @Primary의 반대 개념
 @Component

--- a/src/main/java/tobyspring/splearn/adapter/security/SecurePasswordEncoder.java
+++ b/src/main/java/tobyspring/splearn/adapter/security/SecurePasswordEncoder.java
@@ -2,7 +2,7 @@ package tobyspring.splearn.adapter.security;
 
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Component;
-import tobyspring.splearn.domain.PasswordEncoder;
+import tobyspring.splearn.domain.member.PasswordEncoder;
 
 @Component
 public class SecurePasswordEncoder implements PasswordEncoder {

--- a/src/main/java/tobyspring/splearn/application/member/MemberModifyService.java
+++ b/src/main/java/tobyspring/splearn/application/member/MemberModifyService.java
@@ -1,15 +1,19 @@
-package tobyspring.splearn.application;
+package tobyspring.splearn.application.member;
 
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.validation.annotation.Validated;
-import tobyspring.splearn.application.provided.MemberFinder;
-import tobyspring.splearn.application.provided.MemberRegister;
-import tobyspring.splearn.application.required.EmailSender;
-import tobyspring.splearn.application.required.MemberRepository;
-import tobyspring.splearn.domain.*;
+import tobyspring.splearn.application.member.provided.MemberFinder;
+import tobyspring.splearn.application.member.provided.MemberRegister;
+import tobyspring.splearn.application.member.required.EmailSender;
+import tobyspring.splearn.application.member.required.MemberRepository;
+import tobyspring.splearn.domain.member.DuplicateEmailException;
+import tobyspring.splearn.domain.member.Member;
+import tobyspring.splearn.domain.member.MemberRegisterRequest;
+import tobyspring.splearn.domain.member.PasswordEncoder;
+import tobyspring.splearn.domain.shared.Email;
 
 @Service
 @Validated

--- a/src/main/java/tobyspring/splearn/application/member/MemberQueryService.java
+++ b/src/main/java/tobyspring/splearn/application/member/MemberQueryService.java
@@ -1,12 +1,12 @@
-package tobyspring.splearn.application;
+package tobyspring.splearn.application.member;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.validation.annotation.Validated;
-import tobyspring.splearn.application.provided.MemberFinder;
-import tobyspring.splearn.application.required.MemberRepository;
-import tobyspring.splearn.domain.Member;
+import tobyspring.splearn.application.member.provided.MemberFinder;
+import tobyspring.splearn.application.member.required.MemberRepository;
+import tobyspring.splearn.domain.member.Member;
 
 @Service
 @Validated

--- a/src/main/java/tobyspring/splearn/application/member/provided/MemberFinder.java
+++ b/src/main/java/tobyspring/splearn/application/member/provided/MemberFinder.java
@@ -1,6 +1,6 @@
-package tobyspring.splearn.application.provided;
+package tobyspring.splearn.application.member.provided;
 
-import tobyspring.splearn.domain.Member;
+import tobyspring.splearn.domain.member.Member;
 
 /**
  * 회원을 조회한다.

--- a/src/main/java/tobyspring/splearn/application/member/provided/MemberRegister.java
+++ b/src/main/java/tobyspring/splearn/application/member/provided/MemberRegister.java
@@ -1,8 +1,8 @@
-package tobyspring.splearn.application.provided;
+package tobyspring.splearn.application.member.provided;
 
 import jakarta.validation.Valid;
-import tobyspring.splearn.domain.Member;
-import tobyspring.splearn.domain.MemberRegisterRequest;
+import tobyspring.splearn.domain.member.Member;
+import tobyspring.splearn.domain.member.MemberRegisterRequest;
 
 /**
  * 회원의 등록과 관련된 작업을 한다.

--- a/src/main/java/tobyspring/splearn/application/member/required/EmailSender.java
+++ b/src/main/java/tobyspring/splearn/application/member/required/EmailSender.java
@@ -1,6 +1,6 @@
-package tobyspring.splearn.application.required;
+package tobyspring.splearn.application.member.required;
 
-import tobyspring.splearn.domain.Email;
+import tobyspring.splearn.domain.shared.Email;
 
 /**
  * 이메일을 발송한다.

--- a/src/main/java/tobyspring/splearn/application/member/required/MemberRepository.java
+++ b/src/main/java/tobyspring/splearn/application/member/required/MemberRepository.java
@@ -1,8 +1,8 @@
-package tobyspring.splearn.application.required;
+package tobyspring.splearn.application.member.required;
 
 import org.springframework.data.repository.Repository;
-import tobyspring.splearn.domain.Email;
-import tobyspring.splearn.domain.Member;
+import tobyspring.splearn.domain.shared.Email;
+import tobyspring.splearn.domain.member.Member;
 
 import java.util.Optional;
 

--- a/src/main/java/tobyspring/splearn/domain/Member.java
+++ b/src/main/java/tobyspring/splearn/domain/Member.java
@@ -36,6 +36,8 @@ public class Member extends AbstractEntity {
 
     private MemberStatus status;
 
+    private MemberDetail detail;
+
     public static Member register(MemberRegisterRequest memberRegisterRequest, PasswordEncoder passwordEncoder) {
         Member member = new Member();
 

--- a/src/main/java/tobyspring/splearn/domain/MemberDetail.java
+++ b/src/main/java/tobyspring/splearn/domain/MemberDetail.java
@@ -1,0 +1,30 @@
+package tobyspring.splearn.domain;
+
+import jakarta.persistence.Entity;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.hibernate.annotations.NaturalId;
+import org.hibernate.annotations.NaturalIdCache;
+
+import java.time.LocalDateTime;
+
+import static java.util.Objects.requireNonNull;
+import static lombok.AccessLevel.PROTECTED;
+import static org.springframework.util.Assert.state;
+
+@Entity
+@Getter
+@ToString(callSuper = true)
+@NoArgsConstructor(access = PROTECTED)
+public class MemberDetail extends AbstractEntity {
+    private String profile;
+
+    private String introduction;
+
+    private LocalDateTime registeredAt;
+
+    private LocalDateTime activatedAt;
+
+    private LocalDateTime deactivatedAt;
+}

--- a/src/main/java/tobyspring/splearn/domain/member/DuplicateEmailException.java
+++ b/src/main/java/tobyspring/splearn/domain/member/DuplicateEmailException.java
@@ -1,4 +1,4 @@
-package tobyspring.splearn.domain;
+package tobyspring.splearn.domain.member;
 
 public class DuplicateEmailException extends RuntimeException {
 

--- a/src/main/java/tobyspring/splearn/domain/member/Member.java
+++ b/src/main/java/tobyspring/splearn/domain/member/Member.java
@@ -1,4 +1,4 @@
-package tobyspring.splearn.domain;
+package tobyspring.splearn.domain.member;
 
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -6,6 +6,8 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.hibernate.annotations.NaturalId;
 import org.hibernate.annotations.NaturalIdCache;
+import tobyspring.splearn.domain.AbstractEntity;
+import tobyspring.splearn.domain.shared.Email;
 
 import static java.util.Objects.requireNonNull;
 import static lombok.AccessLevel.PROTECTED;
@@ -36,6 +38,7 @@ public class Member extends AbstractEntity {
 
     private MemberStatus status;
 
+    @OneToOne
     private MemberDetail detail;
 
     public static Member register(MemberRegisterRequest memberRegisterRequest, PasswordEncoder passwordEncoder) {

--- a/src/main/java/tobyspring/splearn/domain/member/Member.java
+++ b/src/main/java/tobyspring/splearn/domain/member/Member.java
@@ -9,6 +9,8 @@ import org.hibernate.annotations.NaturalIdCache;
 import tobyspring.splearn.domain.AbstractEntity;
 import tobyspring.splearn.domain.shared.Email;
 
+import java.util.Objects;
+
 import static java.util.Objects.requireNonNull;
 import static lombok.AccessLevel.PROTECTED;
 import static org.springframework.util.Assert.state;
@@ -65,6 +67,12 @@ public class Member extends AbstractEntity {
 
         this.status = MemberStatus.DEACTIVATED;
         this.detail.deactivated();
+    }
+
+    public void updateInfo(MemberInfoUpdateRequest updateRequest) {
+        this.nickname = Objects.requireNonNull(updateRequest.nickname());
+
+        this.detail.updateInfo(updateRequest);
     }
 
     public boolean verifyPassword(String password, PasswordEncoder passwordEncoder) {

--- a/src/main/java/tobyspring/splearn/domain/member/MemberDetail.java
+++ b/src/main/java/tobyspring/splearn/domain/member/MemberDetail.java
@@ -1,11 +1,10 @@
-package tobyspring.splearn.domain;
+package tobyspring.splearn.domain.member;
 
 import jakarta.persistence.Entity;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-import org.hibernate.annotations.NaturalId;
-import org.hibernate.annotations.NaturalIdCache;
+import tobyspring.splearn.domain.AbstractEntity;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/tobyspring/splearn/domain/member/MemberDetail.java
+++ b/src/main/java/tobyspring/splearn/domain/member/MemberDetail.java
@@ -1,9 +1,11 @@
 package tobyspring.splearn.domain.member;
 
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.springframework.util.Assert;
 import tobyspring.splearn.domain.AbstractEntity;
 
 import java.time.LocalDateTime;
@@ -17,7 +19,8 @@ import static org.springframework.util.Assert.state;
 @ToString(callSuper = true)
 @NoArgsConstructor(access = PROTECTED)
 public class MemberDetail extends AbstractEntity {
-    private String profile;
+    @Embedded
+    private Profile profile;
 
     private String introduction;
 
@@ -26,4 +29,23 @@ public class MemberDetail extends AbstractEntity {
     private LocalDateTime activatedAt;
 
     private LocalDateTime deactivatedAt;
+
+    static MemberDetail create() {
+        MemberDetail memberDetail = new MemberDetail();
+        memberDetail.registeredAt = LocalDateTime.now();
+
+        return memberDetail;
+    }
+
+    public void activated() {
+        Assert.isTrue(activatedAt == null, "이미 ActivatedAt는 설정되었습니다.");
+
+        this.activatedAt = LocalDateTime.now();
+    }
+
+    public void deactivated() {
+        Assert.isTrue(deactivatedAt == null, "이미 DeactivatedAt는 설정되었습니다.");
+
+        this.deactivatedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/tobyspring/splearn/domain/member/MemberDetail.java
+++ b/src/main/java/tobyspring/splearn/domain/member/MemberDetail.java
@@ -9,6 +9,7 @@ import org.springframework.util.Assert;
 import tobyspring.splearn.domain.AbstractEntity;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
 import static lombok.AccessLevel.PROTECTED;
@@ -37,15 +38,20 @@ public class MemberDetail extends AbstractEntity {
         return memberDetail;
     }
 
-    public void activated() {
+    void activated() {
         Assert.isTrue(activatedAt == null, "이미 ActivatedAt는 설정되었습니다.");
 
         this.activatedAt = LocalDateTime.now();
     }
 
-    public void deactivated() {
+    void deactivated() {
         Assert.isTrue(deactivatedAt == null, "이미 DeactivatedAt는 설정되었습니다.");
 
         this.deactivatedAt = LocalDateTime.now();
+    }
+
+    void updateInfo(MemberInfoUpdateRequest updateRequest) {
+        this.profile = new Profile(updateRequest.profileAddress());
+        this.introduction = Objects.requireNonNull(updateRequest.introduction());
     }
 }

--- a/src/main/java/tobyspring/splearn/domain/member/MemberInfoUpdateRequest.java
+++ b/src/main/java/tobyspring/splearn/domain/member/MemberInfoUpdateRequest.java
@@ -1,0 +1,8 @@
+package tobyspring.splearn.domain.member;
+
+public record MemberInfoUpdateRequest(
+        String nickname,
+        String profileAddress,
+        String introduction
+) {
+}

--- a/src/main/java/tobyspring/splearn/domain/member/MemberRegisterRequest.java
+++ b/src/main/java/tobyspring/splearn/domain/member/MemberRegisterRequest.java
@@ -1,4 +1,4 @@
-package tobyspring.splearn.domain;
+package tobyspring.splearn.domain.member;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Size;

--- a/src/main/java/tobyspring/splearn/domain/member/MemberStatus.java
+++ b/src/main/java/tobyspring/splearn/domain/member/MemberStatus.java
@@ -1,4 +1,4 @@
-package tobyspring.splearn.domain;
+package tobyspring.splearn.domain.member;
 
 public enum MemberStatus {
     PENDING, ACTIVE, DEACTIVATED

--- a/src/main/java/tobyspring/splearn/domain/member/PasswordEncoder.java
+++ b/src/main/java/tobyspring/splearn/domain/member/PasswordEncoder.java
@@ -1,4 +1,4 @@
-package tobyspring.splearn.domain;
+package tobyspring.splearn.domain.member;
 
 /**
  * PasswordEncoder의 기술적인 요소 때문에 required에 위치시켜야하는 의문이 들 수 있음

--- a/src/main/java/tobyspring/splearn/domain/member/Profile.java
+++ b/src/main/java/tobyspring/splearn/domain/member/Profile.java
@@ -17,4 +17,8 @@ public record Profile(String address) {
             throw new IllegalArgumentException("프로필 주소는 최대 15자리를 넘을 수 없습니다.");
         }
     }
+
+    public String url() {
+        return "@" + address;
+    }
 }

--- a/src/main/java/tobyspring/splearn/domain/member/Profile.java
+++ b/src/main/java/tobyspring/splearn/domain/member/Profile.java
@@ -1,0 +1,20 @@
+package tobyspring.splearn.domain.member;
+
+import jakarta.persistence.Embeddable;
+
+import java.util.regex.Pattern;
+
+@Embeddable
+public record Profile(String address) {
+    private static final Pattern PROFILE_ADDRESS_PATTERN = Pattern.compile("[a-z0-9]+");
+
+    public Profile {
+        if (!PROFILE_ADDRESS_PATTERN.matcher(address).matches()) {
+            throw new IllegalArgumentException("프로필 주소 형식이 바르지 않습니다: " + address);
+        }
+
+        if (address.length() > 15) {
+            throw new IllegalArgumentException("프로필 주소는 최대 15자리를 넘을 수 없습니다.");
+        }
+    }
+}

--- a/src/main/java/tobyspring/splearn/domain/shared/Email.java
+++ b/src/main/java/tobyspring/splearn/domain/shared/Email.java
@@ -1,7 +1,4 @@
-package tobyspring.splearn.domain;
-
-import jakarta.persistence.Column;
-import jakarta.persistence.Embeddable;
+package tobyspring.splearn.domain.shared;
 
 import java.util.regex.Pattern;
 

--- a/src/main/resources/META-INF/orm.xml
+++ b/src/main/resources/META-INF/orm.xml
@@ -18,7 +18,7 @@
     <!-- XML 방식으로 할경우 class 경로가 맞는지 확인해야 함 -->
     <!-- 클래스 경로가 다를 경우 ClassLoadingException 발생 -->
     <!-- XML 방식을 사용할 경우 리팩토링하면서 클래스 경로를 재 배치했을 때, 해당 이슈를 바로 확인하기 어려운 점 존재 -->
-    <entity class="tobyspring.splearn.domain.Member">
+    <entity class="tobyspring.splearn.domain.member.Member">
         <table name="member">
             <unique-constraint name="UK_MEMBER_EMAIL_ADDRESS">
                 <column-name>email_address</column-name>
@@ -40,7 +40,7 @@
         </attributes>
     </entity>
 
-    <embeddable class="tobyspring.splearn.domain.Email">
+    <embeddable class="tobyspring.splearn.domain.shared.Email">
         <attributes>
             <basic name="address">
                 <column name="email_address" nullable="false" length="150"/>

--- a/src/test/java/tobyspring/splearn/SplearnTestConfiguration.java
+++ b/src/test/java/tobyspring/splearn/SplearnTestConfiguration.java
@@ -2,9 +2,9 @@ package tobyspring.splearn;
 
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
-import tobyspring.splearn.application.required.EmailSender;
-import tobyspring.splearn.domain.MemberFixture;
-import tobyspring.splearn.domain.PasswordEncoder;
+import tobyspring.splearn.application.member.required.EmailSender;
+import tobyspring.splearn.domain.member.MemberFixture;
+import tobyspring.splearn.domain.member.PasswordEncoder;
 
 @TestConfiguration
 public class SplearnTestConfiguration {

--- a/src/test/java/tobyspring/splearn/adapter/integration/DummyEmailSenderTest.java
+++ b/src/test/java/tobyspring/splearn/adapter/integration/DummyEmailSenderTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.StdIo;
 import org.junitpioneer.jupiter.StdOut;
-import tobyspring.splearn.domain.Email;
+import tobyspring.splearn.domain.shared.Email;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/src/test/java/tobyspring/splearn/application/member/provided/MemberFinderTest.java
+++ b/src/test/java/tobyspring/splearn/application/member/provided/MemberFinderTest.java
@@ -1,4 +1,4 @@
-package tobyspring.splearn.application.provided;
+package tobyspring.splearn.application.member.provided;
 
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
@@ -7,8 +7,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import tobyspring.splearn.SplearnTestConfiguration;
-import tobyspring.splearn.domain.Member;
-import tobyspring.splearn.domain.MemberFixture;
+import tobyspring.splearn.domain.member.Member;
+import tobyspring.splearn.domain.member.MemberFixture;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/src/test/java/tobyspring/splearn/application/member/provided/MemberRegisterManualTest.java
+++ b/src/test/java/tobyspring/splearn/application/member/provided/MemberRegisterManualTest.java
@@ -1,16 +1,16 @@
-package tobyspring.splearn.application.provided;
+package tobyspring.splearn.application.member.provided;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.test.util.ReflectionTestUtils;
-import tobyspring.splearn.application.MemberModifyService;
-import tobyspring.splearn.application.required.EmailSender;
-import tobyspring.splearn.application.required.MemberRepository;
-import tobyspring.splearn.domain.Email;
-import tobyspring.splearn.domain.Member;
-import tobyspring.splearn.domain.MemberFixture;
-import tobyspring.splearn.domain.MemberStatus;
+import tobyspring.splearn.application.member.MemberModifyService;
+import tobyspring.splearn.application.member.required.EmailSender;
+import tobyspring.splearn.application.member.required.MemberRepository;
+import tobyspring.splearn.domain.shared.Email;
+import tobyspring.splearn.domain.member.Member;
+import tobyspring.splearn.domain.member.MemberFixture;
+import tobyspring.splearn.domain.member.MemberStatus;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/test/java/tobyspring/splearn/application/member/provided/MemberRegisterTest.java
+++ b/src/test/java/tobyspring/splearn/application/member/provided/MemberRegisterTest.java
@@ -1,4 +1,4 @@
-package tobyspring.splearn.application.provided;
+package tobyspring.splearn.application.member.provided;
 
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
@@ -10,7 +10,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import tobyspring.splearn.SplearnTestConfiguration;
-import tobyspring.splearn.domain.*;
+import tobyspring.splearn.domain.member.*;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;

--- a/src/test/java/tobyspring/splearn/application/member/required/MemberRepositoryTest.java
+++ b/src/test/java/tobyspring/splearn/application/member/required/MemberRepositoryTest.java
@@ -7,7 +7,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.dao.DataIntegrityViolationException;
 import tobyspring.splearn.domain.member.Member;
+import tobyspring.splearn.domain.member.MemberStatus;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static tobyspring.splearn.domain.member.MemberFixture.createMemberRegisterRequest;
@@ -34,6 +36,11 @@ class MemberRepositoryTest {
         assertThat(member.getId()).isNotNull();
 
         entityManager.flush();
+        entityManager.clear();
+
+        var found = memberRepository.findById(member.getId()).orElseThrow();
+        assertThat(found.getStatus()).isEqualTo(MemberStatus.PENDING);
+        assertThat(found.getDetail().getRegisteredAt()).isNotNull();
     }
 
     @Test

--- a/src/test/java/tobyspring/splearn/application/member/required/MemberRepositoryTest.java
+++ b/src/test/java/tobyspring/splearn/application/member/required/MemberRepositoryTest.java
@@ -1,4 +1,4 @@
-package tobyspring.splearn.application.required;
+package tobyspring.splearn.application.member.required;
 
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
@@ -6,12 +6,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.dao.DataIntegrityViolationException;
-import tobyspring.splearn.domain.Member;
+import tobyspring.splearn.domain.member.Member;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static tobyspring.splearn.domain.MemberFixture.createMemberRegisterRequest;
-import static tobyspring.splearn.domain.MemberFixture.createPasswordEncoder;
+import static tobyspring.splearn.domain.member.MemberFixture.createMemberRegisterRequest;
+import static tobyspring.splearn.domain.member.MemberFixture.createPasswordEncoder;
 
 @DataJpaTest
 @DisplayName("MemberRepository")

--- a/src/test/java/tobyspring/splearn/domain/member/MemberFixture.java
+++ b/src/test/java/tobyspring/splearn/domain/member/MemberFixture.java
@@ -1,4 +1,4 @@
-package tobyspring.splearn.domain;
+package tobyspring.splearn.domain.member;
 
 public class MemberFixture {
 

--- a/src/test/java/tobyspring/splearn/domain/member/MemberTest.java
+++ b/src/test/java/tobyspring/splearn/domain/member/MemberTest.java
@@ -27,6 +27,7 @@ class MemberTest {
     @DisplayName("Member를 생성한다.")
     void test1() {
         assertThat(member.getStatus()).isEqualTo(MemberStatus.PENDING);
+        assertThat(member.getDetail().getRegisteredAt()).isNotNull();
     }
 
     @Disabled("SpotBug 플러그인에서 Nullable을 체크하여 Disabled 처리")
@@ -40,9 +41,12 @@ class MemberTest {
     @Test
     @DisplayName("activate()는 Member를 활성 상태로 변경한다.")
     void test3() {
+        assertThat(member.getDetail().getActivatedAt()).isNull();
+
         member.activate();
 
         assertThat(member.getStatus()).isEqualTo(MemberStatus.ACTIVE);
+        assertThat(member.getDetail().getActivatedAt()).isNotNull();
     }
 
     @Test

--- a/src/test/java/tobyspring/splearn/domain/member/MemberTest.java
+++ b/src/test/java/tobyspring/splearn/domain/member/MemberTest.java
@@ -129,4 +129,17 @@ class MemberTest {
 
         Member.register(createMemberRegisterRequest(), passwordEncoder);
     }
+
+    @Test
+    @DisplayName("updateInfo()")
+    void test12() {
+        member.activate();
+
+        var request = new MemberInfoUpdateRequest("macbook", "www01234", "자기소개");
+        member.updateInfo(request);
+        
+        assertThat(member.getNickname()).isEqualTo(request.nickname());
+        assertThat(member.getDetail().getProfile().address()).isEqualTo(request.profileAddress());
+        assertThat(member.getDetail().getIntroduction()).isEqualTo(request.introduction());
+    }
 }

--- a/src/test/java/tobyspring/splearn/domain/member/MemberTest.java
+++ b/src/test/java/tobyspring/splearn/domain/member/MemberTest.java
@@ -1,4 +1,4 @@
-package tobyspring.splearn.domain;
+package tobyspring.splearn.domain.member;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -7,8 +7,8 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
-import static tobyspring.splearn.domain.MemberFixture.createMemberRegisterRequest;
-import static tobyspring.splearn.domain.MemberFixture.createPasswordEncoder;
+import static tobyspring.splearn.domain.member.MemberFixture.createMemberRegisterRequest;
+import static tobyspring.splearn.domain.member.MemberFixture.createPasswordEncoder;
 
 @DisplayName("Member")
 class MemberTest {

--- a/src/test/java/tobyspring/splearn/domain/member/ProfileTest.java
+++ b/src/test/java/tobyspring/splearn/domain/member/ProfileTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
 
 class ProfileTest {
 

--- a/src/test/java/tobyspring/splearn/domain/member/ProfileTest.java
+++ b/src/test/java/tobyspring/splearn/domain/member/ProfileTest.java
@@ -1,0 +1,27 @@
+package tobyspring.splearn.domain.member;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ProfileTest {
+
+    @Test
+    @DisplayName("Profile은 15자리 미만 영문과 숫자만 가능")
+    void test1 () {
+        new Profile("xxxxx");
+        new Profile("xxxxx");
+        new Profile("123456");
+    }
+
+    @Test
+    @DisplayName("Profile 실패 케이스")
+    void test2() {
+//        assertThatThrownBy(() -> new Profile("")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new Profile("12345678901234567")).isInstanceOf(IllegalArgumentException.class);
+//        assertThatThrownBy(() -> new Profile("XXXX")).isInstanceOf(IllegalArgumentException.class);
+//        assertThatThrownBy(() -> new Profile("프로필")).isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/tobyspring/splearn/domain/member/ProfileTest.java
+++ b/src/test/java/tobyspring/splearn/domain/member/ProfileTest.java
@@ -3,6 +3,7 @@ package tobyspring.splearn.domain.member;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -19,9 +20,17 @@ class ProfileTest {
     @Test
     @DisplayName("Profile 실패 케이스")
     void test2() {
-//        assertThatThrownBy(() -> new Profile("")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new Profile("")).isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> new Profile("12345678901234567")).isInstanceOf(IllegalArgumentException.class);
-//        assertThatThrownBy(() -> new Profile("XXXX")).isInstanceOf(IllegalArgumentException.class);
-//        assertThatThrownBy(() -> new Profile("프로필")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new Profile("XXXX")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new Profile("프로필")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("url()")
+    void test3() {
+        var profile = new Profile("macbook");
+
+        assertThat(profile.url()).isEqualTo("@macbook");
     }
 }

--- a/src/test/java/tobyspring/splearn/domain/shared/EmailTest.java
+++ b/src/test/java/tobyspring/splearn/domain/shared/EmailTest.java
@@ -1,4 +1,4 @@
-package tobyspring.splearn.domain;
+package tobyspring.splearn.domain.shared;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/도메인모델.md
+++ b/도메인모델.md
@@ -50,6 +50,7 @@ _Entity_
 - `nickname`: 닉네임
 - `passwordHash`: 비밀번호
 - `status`: `MemberStatus` 회원 상태
+- `detail`: `MemberDetail` 1:1
 #### 행위
 - `static register()`: 회원 등록: email. nickname, password, passwordEncoder
 - `activate()`: 등록을 완료 시킨다
@@ -63,6 +64,15 @@ _Entity_
 - 등록 대기 상태에서만 등록 완료가 될 수 있다
 - 등록 완료 상태에서는 탈퇴할 수 있다
 - 회원의 비밀번호는 해시를 만들어서 저장한다
+
+### 회원 상세(MemberDetail)
+_Entity_
+- `id`: `Long`
+- `profile`: 프로필 주소. 모든 회원이 고유한 프로필 주소를 가져야 한다
+- `introduction`: 자기 소개
+- `registeredAt`: 등록 일시
+- `activatedAt`: 등록 완료 일시
+- `deactivatedAt`: 탈퇴 일시
 
 ### 회원 상태(MemberStatus)
 _Enum_


### PR DESCRIPTION
프로젝트 셋팅할 때마다 AuditEntity와 같이 공유 파일을 어디에 둘지 고민이었는데, `common`은 사용하기 싫었고, `shared`라는 패키지명 괜찮은 것 같음

Aggregate Root는 알고 있던 개념과 동일
데이터 라이프 사이클을 맞추기 위함

먼저 JPA 엔티티에 필요한 어노테이션을 선언하여 개발하고, 그 이후에 XML로 변환